### PR TITLE
Improve sample rates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,7 @@ impl<B: UsbBus> UsbClass<B> for AudioClass<'_, B> {
 pub struct AudioClassBuilder<'a> {
     input: Option<StreamConfig<'a>>,
     output: Option<StreamConfig<'a>>,
+    sample_rate: Option<u16>,
     marker: PhantomData<&'a u8>,
 }
 
@@ -562,6 +563,7 @@ impl<'a> AudioClassBuilder<'a> {
         AudioClassBuilder {
             input: None,
             output: None,
+            sample_rate: None,
             marker: PhantomData,
         }
     }
@@ -570,6 +572,7 @@ impl<'a> AudioClassBuilder<'a> {
         AudioClassBuilder {
             input: Some(input),
             output: self.output,
+            sample_rate: self.sample_rate,
             marker: self.marker,
         }
     }
@@ -578,6 +581,16 @@ impl<'a> AudioClassBuilder<'a> {
         AudioClassBuilder {
             input: self.input,
             output: Some(output),
+            sample_rate: self.sample_rate,
+            marker: self.marker,
+        }
+    }
+
+    pub fn sample_rate(self, sample_rate: u16) -> AudioClassBuilder<'a> {
+        AudioClassBuilder {
+            input: self.input,
+            output: self.output,
+            sample_rate: Some(sample_rate),
             marker: self.marker,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -604,6 +604,10 @@ impl<'a> AudioClassBuilder<'a> {
             clock_index: 0,
         };
 
+        if self.sample_rate == None {
+            panic!("A sample rate must be provided with sample_rate().");
+        }
+
         if let Some(input_config) = self.input {
 
             let input_interface = allocator.interface();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,8 @@ impl<B: UsbBus, const R: u16> UsbClass<B> for AudioClass<'_, B, R> {
                 && (req.value >> 8) == 0x01 // clock freq control selector
         ) {
 
+            let rate: [u8; 2] = R.to_be_bytes();
+
             // range request
             if (req.request == 0x02) {
                 match self.clock_index {
@@ -522,8 +524,8 @@ impl<B: UsbBus, const R: u16> UsbClass<B> for AudioClass<'_, B, R> {
                     _ => {
                         xfer.accept_with(&[
                             0x01, 0x00, // subranges
-                            0x80, 0x3E, 0x00, 0x00, // min
-                            0x80, 0x3E, 0x00, 0x00, // max
+                            rate[0], rate[1], 0x00, 0x00, // min
+                            rate[0], rate[1], 0x00, 0x00, // max
                             0x01, 0x00, 0x00, 0x00  // res
                         ]).ok();
                         self.clock_index += 1;
@@ -535,7 +537,7 @@ impl<B: UsbBus, const R: u16> UsbClass<B> for AudioClass<'_, B, R> {
             // current value request
             else if (req.request == 0x01) {
                 xfer.accept_with(&[
-                    0x80, 0x3E, 0x00, 0x00
+                    rate[0], rate[1], 0x00, 0x00
                 ]).ok();
                 return;
             }


### PR DESCRIPTION
Fixed the way sample rates are handled such that IN and OUT streams cannot be mismatched for synchronous audio. A single shared clock source descriptor is used and as such, the streams must have the same sample rate for synchronous audio to work.